### PR TITLE
fix: チャットに投稿するときのユーザ名をフルネームに変更

### DIFF
--- a/attendance-ext/contentScript.js
+++ b/attendance-ext/contentScript.js
@@ -12,7 +12,8 @@ if (userElem && userElem.hasChildNodes()) {
 } else {
     userElem = document.getElementsByClassName("attendance-mobile-header-user-name")[0];
 }
-const user = userElem.innerText.split(" ")[0];
+const re = /^(.+?)さん$/
+const user = re.exec(userElem.innerText)[1];
 // console.log(user);
 
 let chatConf = {};


### PR DESCRIPTION
同姓の方がいる場合苗字のみでの投稿だと混乱を招くかと思いましてフルネームで表示できるように変更しました。

意図にあった修正か分かりませんが良ければ取り込んで頂ければ幸いです。